### PR TITLE
Update documentation; bump to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Polly.Contrib.WaitAndRetry changelog
 
-## 0.1.0
-- First version
+## 1.0.0
+- Launch version

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 0.1.0
+next-version: 1.0.0

--- a/src/GlobalAssemblyInfo.cs
+++ b/src/GlobalAssemblyInfo.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 
 [assembly: AssemblyProduct("Polly.Contrib.WaitAndRetry")]
 [assembly: AssemblyCompany("App vNext")]
-[assembly: AssemblyDescription("Polly is a library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.")]
-[assembly: AssemblyCopyright("Copyright (c) 2018, App vNext")]
+[assembly: AssemblyDescription("Polly.Contrib.WaitAndRetry is an extension library for Polly containing helper methods for a variety of wait-and-retry strategies.")]
+[assembly: AssemblyCopyright("Copyright (c) 2019, App vNext and contributors")]
 
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]

--- a/src/Polly.Contrib.WaitAndRetry.nuspec
+++ b/src/Polly.Contrib.WaitAndRetry.nuspec
@@ -19,10 +19,12 @@
     <dependencies>
       <group targetFramework="netstandard1.1">
         <dependency id="NETStandard.Library" version="1.6.1" />
-        <dependency id="Polly" version="7.0.3" />
+        <!-- The Polly dependency is artificial right now, nothing uses it. -->
+        <!-- <dependency id="Polly" version="7.1.0" /> -->
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="Polly" version="7.0.3" />
+        <!-- The Polly dependency is artificial right now, nothing uses it. -->
+        <!-- <dependency id="Polly" version="7.1.0" /> -->
       </group>
     </dependencies>
   </metadata>

--- a/src/Polly.Contrib.WaitAndRetry.nuspec
+++ b/src/Polly.Contrib.WaitAndRetry.nuspec
@@ -12,9 +12,9 @@
     <projectUrl>https://github.com/Polly-Contrib/Polly.Contrib.WaitAndRetry</projectUrl>
     <copyright>Copyright © 2019, App vNext and contributors</copyright>
     <releaseNotes>
-      0.1.0
+      1.0.0
       ---------------------
-      - Initial launch
+      - Launch version
     </releaseNotes>
     <dependencies>
       <group targetFramework="netstandard1.1">

--- a/src/Polly.Contrib.WaitAndRetry.nuspec
+++ b/src/Polly.Contrib.WaitAndRetry.nuspec
@@ -2,14 +2,14 @@
 <package>
   <metadata>
     <owners>App vNext</owners>
-    <authors>Grant Dickinson ,App vNext</authors>
+    <authors>Grant Dickinson, App vNext</authors>
     <description>
-      Polly is a .NET Standard 1.1 and .NET Standard 2.0 library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation and Fallback in a fluent and thread-safe manner.
+      Polly.Contrib.WaitAndRetry is an extension library for Polly containing helper methods for a variety of wait-and-retry strategies.
     </description>
     <language>en-US</language>
     <license type="expression">BSD-3-Clause</license>
     <iconUrl>https://raw.github.com/App-vNext/Polly/master/Polly.png</iconUrl>
-    <projectUrl>https://github.com/Polly-Contrib/Polly.Contrib.BlankTemplate</projectUrl>
+    <projectUrl>https://github.com/Polly-Contrib/Polly.Contrib.WaitAndRetry</projectUrl>
     <copyright>Copyright © 2019, App vNext and contributors</copyright>
     <releaseNotes>
       0.1.0

--- a/src/Polly.Contrib.WaitAndRetry/Polly.Contrib.WaitAndRetry.csproj
+++ b/src/Polly.Contrib.WaitAndRetry/Polly.Contrib.WaitAndRetry.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <!-- The Polly dependency is artificial right now, nothing uses it. -->
-    <!--<PackageReference Include="Polly" Version="7.0.3" />-->
+    <!--<PackageReference Include="Polly" Version="7.1.0" />-->
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Polly.Contrib.WaitAndRetry/Polly.Contrib.WaitAndRetry.csproj
+++ b/src/Polly.Contrib.WaitAndRetry/Polly.Contrib.WaitAndRetry.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.1.0-v010-0001</Version>
-    <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <FileVersion>0.1.0.0</FileVersion>
-    <InformationalVersion>0.1.0.0</InformationalVersion>
-    <PackageVersion>0.1.0-v010-0001</PackageVersion>
+    <Version>1.0.0-bumptov100-0001</Version>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+    <InformationalVersion>1.0.0.0</InformationalVersion>
+    <PackageVersion>1.0.0-bumptov100-0001</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Updates some wording in the documentation

Bumps to v1.0.0 (the code is stable enough that we don't need first release to be a v0.1.0)

@grant-d Please feel free to merge if you are happy with this!