### PR TITLE
Add range tests on AwsDecorrelatedJitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Polly.Contrib.WaitAndRetry changelog
 
+## vNext
+- Extend tests on original jitter policy to cover range of seed values
+
 ## 1.0.0
 - Launch version

--- a/src/Polly.Contrib.WaitAndRetry.Specs/AwsDecorrelatedJitterBackoffSpecs.cs
+++ b/src/Polly.Contrib.WaitAndRetry.Specs/AwsDecorrelatedJitterBackoffSpecs.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Polly.Contrib.WaitAndRetry.Specs.Utilities;
 using Xunit;
 
 namespace Polly.Contrib.WaitAndRetry.Specs
@@ -108,21 +109,22 @@ namespace Polly.Contrib.WaitAndRetry.Specs
                 }
                 else
                 {
-                    timeSpan.Should().BeGreaterOrEqualTo(minDelay);
-                    timeSpan.Should().BeLessOrEqualTo(maxDelay);
+                    timeSpan.ShouldBeBetweenOrEqualTo(minDelay, maxDelay);
                 }
             }
         }
 
-        [Fact]
-        public void Backoff_ResultIsInRange()
+        public static IEnumerable<object[]> SeedRange => Enumerable.Range(0, 1000).Select(o => new object[] { o }).ToArray();
+
+        [Theory]
+        [MemberData(nameof(SeedRange))]
+        public void Backoff_ResultIsInRange(int seed)
         {
             // Arrange
             var minDelay = TimeSpan.FromMilliseconds(10);
             var maxDelay = TimeSpan.FromMilliseconds(100);
             const int retryCount = 3;
             const bool fastFirst = false;
-            const int seed = 100;
 
             // Act
             IEnumerable<TimeSpan> result = Backoff.AwsDecorrelatedJitterBackoff(minDelay, maxDelay, retryCount, seed, fastFirst);
@@ -134,8 +136,7 @@ namespace Polly.Contrib.WaitAndRetry.Specs
 
             foreach (TimeSpan timeSpan in result)
             {
-                timeSpan.Should().BeGreaterOrEqualTo(minDelay);
-                timeSpan.Should().BeLessOrEqualTo(maxDelay);
+                timeSpan.ShouldBeBetweenOrEqualTo(minDelay, maxDelay);
             }
         }
     }

--- a/src/Polly.Contrib.WaitAndRetry.Specs/DecorrelatedJitterBackoffV2Specs.cs
+++ b/src/Polly.Contrib.WaitAndRetry.Specs/DecorrelatedJitterBackoffV2Specs.cs
@@ -100,37 +100,12 @@ namespace Polly.Contrib.WaitAndRetry.Specs
                 }
             }
         }
-
-        [Fact]
-        public void Backoff_ResultIsInRange()
-        {
-            // Arrange
-            var medianFirstDelay = TimeSpan.FromSeconds(1);
-            const int retryCount = 6;
-            const bool fastFirst = false;
-            const int seed = 23456;
-
-            // Act
-            IEnumerable<TimeSpan> result = Backoff.DecorrelatedJitterBackoffV2(medianFirstDelay, retryCount, seed, fastFirst);
-
-            // Assert
-            result.Should().NotBeNull();
-            result = result.ToList();
-            result.Should().HaveCount(retryCount);
-
-            int t = 0;
-            foreach (TimeSpan timeSpan in result)
-            {
-                t++;
-                AssertOnRetryDelayForTry(t, timeSpan, medianFirstDelay);
-            }
-        }
-
+        
         public static IEnumerable<object[]> SeedRange => Enumerable.Range(0, 1000).Select(o => new object[] {o}).ToArray();
 
         [Theory]
         [MemberData(nameof(SeedRange))]
-        public void Backoff_ResultIsInRange_WideTest(int seed)
+        public void Backoff_ResultIsInRange(int seed)
         {
             // Arrange
             var medianFirstDelay = TimeSpan.FromSeconds(3);

--- a/src/Polly.Contrib.WaitAndRetry.Specs/Utilities/TimeSpanExtensions.cs
+++ b/src/Polly.Contrib.WaitAndRetry.Specs/Utilities/TimeSpanExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using FluentAssertions;
+
+namespace Polly.Contrib.WaitAndRetry.Specs.Utilities
+{
+    public static class TimeSpanExtensions
+    {
+        public static void ShouldBeBetweenOrEqualTo(this TimeSpan timeSpan, TimeSpan minDelay, TimeSpan maxDelay)
+        {
+            timeSpan.Should().BeGreaterOrEqualTo(minDelay);
+            timeSpan.Should().BeLessOrEqualTo(maxDelay);
+        }
+    }
+}


### PR DESCRIPTION
### The issue or feature being addressed

Extend tests on first jitter formula to cover a range of random seed values.

- [x]  I have merged the latest changes from the vXYZ branch
- [x]  I have successfully run a local build
- [x]  I have included unit tests for the issue/feature
- [X] I have made my PR against the vXYZ branch

