### PR TITLE
Add Framework 4.7 to targetted frameworks (Polly-Contrib#22)

### DIFF
--- a/src/Polly.Contrib.WaitAndRetry/Polly.Contrib.WaitAndRetry.csproj
+++ b/src/Polly.Contrib.WaitAndRetry/Polly.Contrib.WaitAndRetry.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;netstandard2.0;net461;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net461;net47;net472</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <AssemblyName>Polly.Contrib.WaitAndRetry</AssemblyName>
     <RootNamespace>Polly.Contrib.WaitAndRetry</RootNamespace>


### PR DESCRIPTION
<!-- Thank you for contributing to Polly.Contrib.WaitAndRetry!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### Polly.Contrib does not compile for us poor souls still on Framework 4.7

<!-- Please include the existing github issue number where relevant -->

### Add Framework 4.7 to list of targets

### Confirm the following

- [X]  I have merged the latest changes from the dev vX.Y branch
- [X]  I have successfully run a local build
- [N/A]  I have included unit tests for the issue/feature
- [X]  I have targeted the PR against the latest dev vX.Y branch
