### PR TITLE
Fixed retryWithBackoffAndOverallTimeout example in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ If the overall amount of time that an exponential-backoff retry policy could tak
     var retryWithBackoff = Policy
         .Handle<FooException>()
         .WaitAndRetryAsync(Backoff.ExponentialBackoff(TimeSpan.FromSeconds(1), retryCount: 5));
-    var timeout = Policy.Timeout(TimeSpan.FromSeconds(45));
-    var retryWithBackoffAndOverallTimeout = timeout.Wrap(retryWithBackoff);
+    var timeout = Policy.TimeoutAsync(TimeSpan.FromSeconds(45));
+    var retryWithBackoffAndOverallTimeout = timeout.WrapAsync(retryWithBackoff);
 
 When the combined time taken to make tries and wait between them exceeds 45 seconds, the TimeoutPolicy will be invoked and cause the current try and further retries to be abandoned.
 


### PR DESCRIPTION
<!-- Thank you for contributing to Polly.Contrib.WaitAndRetry!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The example is not compatible with Polly 7

### Confirm the following

- [x]  I have merged the latest changes from the dev vX.Y branch
- [x]  I have successfully run a local build
- [ ]  I have included unit tests for the issue/feature
- [x]  I have targeted the PR against the latest dev vX.Y branch
